### PR TITLE
Mac OS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ release/
 # Node
 node_modules
 package-lock.json
+
+.DS_Store

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,90 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "make setup",
+      "type": "process",
+      "command": "C:\\Program Files\\Git\\bin\\bash.exe",
+      "args": [
+        "-lc",
+        "export PATH=\"/c/Program Files (x86)/GnuWin32/bin:/c/Program Files/Git/usr/bin:/c/Program Files/Git/cmd:$PATH\"; make setup"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "problemMatcher": [],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "clear": true
+      }
+    },
+    {
+      "label": "make (Rome2 DEV=1)",
+      "type": "process",
+      "command": "C:\\Program Files\\Git\\bin\\bash.exe",
+      "args": [
+        "-lc",
+        "export PATH=\"/c/Program Files (x86)/GnuWin32/bin:/c/Program Files/Git/usr/bin:/c/Program Files/Git/cmd:$PATH\"; make GAME=Rome2 DEV=1"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "problemMatcher": [],
+      "group": {
+        "kind": "build"
+      },
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "clear": true
+      }
+    },
+    {
+      "label": "make clean",
+      "type": "process",
+      "command": "C:\\Program Files\\Git\\bin\\bash.exe",
+      "args": [
+        "-lc",
+        "export PATH=\"/c/Program Files (x86)/GnuWin32/bin:/c/Program Files/Git/usr/bin:/c/Program Files/Git/cmd:$PATH\"; make clean GAME=Rome2"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "problemMatcher": [],
+      "group": {
+        "kind": "build"
+      },
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "clear": true
+      }
+    },
+    {
+      "label": "make Rome2 install macos",
+      "type": "process",
+      "command": "C:\\Program Files\\Git\\bin\\bash.exe",
+      "args": [
+        "-lc",
+        "export PATH=\"/c/Program Files (x86)/GnuWin32/bin:/c/Program Files/Git/usr/bin:/c/Program Files/Git/cmd:$PATH\"; make clean GAME=Rome2 install-steam-macos"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "problemMatcher": [],
+      "group": {
+        "kind": "build"
+      },
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "clear": true
+      }
+    }
+  ]
+}

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,9 @@ ifeq ($(GAME),Rome2)
     RPFM_SCHEMA_FILE := schema_rom2.ron
     INSTALL_ALONE_DIR := D:\Games\Total War - Rome 2 Steam
     INSTALL_STEAM_DIR := C:/Program Files (x86)/Steam/steamapps/common/Total War Rome II
+	INSTALL_STEAM_MACOS_DIR := Z:/Library/Application Support/Steam/steamapps/common/Total War Rome II/TotalWarRome2Data
     INSTALL_USER_SCRIPT := C:/Users/$(USERNAME)/AppData/Roaming/The\ Creative\ Assembly/Rome2/scripts
+	INSTALL_USER_SCRIPT_MACOS :=Z:/Library/Application Support/Feral Interactive/Total War ROME II/VFS/User/AppData/Roaming/The Creative Assembly/Rome2/scripts
     GAME_EXE := Rome2.exe
     STEAM_APP_ID := 214950
     ALL_SCRIPTED_SRC := src/lua_scripts/all_scripted_rome2.lua
@@ -73,6 +75,14 @@ MOD_VERSION = 0.9.2
 # Note:
 # This Makefile has been designed and tested for use with GNU Make in the Git Bash shell.
 # ============================================================
+
+ifeq ($(OS),Windows_NT)
+GIT_SH_CANDIDATES := $(wildcard C:/Program\ Files/Git/usr/bin/sh.exe) $(wildcard C:/Program\ Files/Git/bin/sh.exe) $(wildcard C:/Program\ Files\ \(x86\)/Git/usr/bin/sh.exe) $(wildcard C:/Program\ Files\ \(x86\)/Git/bin/sh.exe)
+ifneq ($(strip $(GIT_SH_CANDIDATES)),)
+else
+$(warning Git Bash / sh.exe was not found in a standard Windows install path. This Makefile's setup target uses POSIX shell syntax and is intended to run from Git Bash.)
+endif
+endif
 
 # Directories for dependencies and build files
 BUILD_DIR         := ./build/$(GAME)
@@ -422,6 +432,7 @@ clean:
 	@rm -f $(RELEASE_DIR)/$(MOD_PACKAGE)
 	@rm -f '$(INSTALL_ALONE_DIR)/data/$(MOD_PACKAGE)'
 	@rm -f '$(INSTALL_STEAM_DIR)/data/$(MOD_PACKAGE)'
+	@rm -f '$(INSTALL_STEAM_MACOS_DIR)/data/$(MOD_PACKAGE)'
 	@echo "Cleaned up build directory and mod package for $(GAME)."
 
 # Setup target to prepare all necessary dependencies
@@ -596,11 +607,18 @@ generate-docs: setup-lua setup-lua-libs setup-ldoc
 # Install Steam and alone
 install: \
 	install-alone \
-	install-steam
+	install-steam \
+	install-steam-macos
 
 # Install the built .pack file only if different for Steam
 install-steam: $(MOD_PACKAGE)
 	$(call install-to-dir,$(INSTALL_STEAM_DIR)/data)
+
+install-steam-macos: $(MOD_PACKAGE)
+	$(call install-to-dir,$(INSTALL_STEAM_MACOS_DIR)/data)
+	@mkdir -p "$(INSTALL_USER_SCRIPT_MACOS)"
+	@echo 'mod "$(MOD_PACKAGE)";' > "$(INSTALL_USER_SCRIPT_MACOS)/user.script.txt"
+	@echo 'mod "$(MOD_PACKAGE)" written to $(INSTALL_USER_SCRIPT_MACOS)/user.script.txt for Steam macOS installation'
 
 # Install the built .pack file only if different for standalone
 install-alone: $(MOD_PACKAGE)
@@ -642,6 +660,8 @@ copy_alone: $(MOD_PACKAGE)
 
 copy_steam: $(MOD_PACKAGE)
 	$(call install-to-dir,$(INSTALL_STEAM_DIR)/data)
+copy_steam_macos: $(MOD_PACKAGE)
+	$(call install-to-dir,$(INSTALL_STEAM_MACOS_DIR)/data)
 
 # Function to install the mod package to a specified directory
 install-to-dir = \
@@ -690,6 +710,9 @@ run-steam: \
 	install-steam
 	@$(disable_outdated_mods_popup)
 	@powershell -Command start steam://rungameid/$(STEAM_APP_ID)
+copy-macos: \	
+	install-steam-macos
+	@$(disable_outdated_mods_popup)
 
 
 # short aliases for the run targets
@@ -787,6 +810,7 @@ bump-version:
 			setup-etwng \
 		install \
 			install-steam \
+			install-steam-macos \
 			install-alone \
 		kill-game \
 		run-alone \

--- a/src/consul/consul.lua
+++ b/src/consul/consul.lua
@@ -83,6 +83,24 @@ consul = {
 
 		consul.env.setup()
 	end,
+	--- Opens a file, prepending the OS-specific base path for relative filenames.
+	--- On Windows the path is used as-is (relative to the game CWD).
+	--- On macOS with Rome2 the base is $HOME/Library/Application Support/Steam/steamapps/common/Total War Rome II/.
+	--- @function consul.io_open
+	--- @tparam string filename The filename (relative or absolute) to open.
+	--- @tparam string mode The mode string passed to io.open.
+	--- @return file*, string The file handle and error message, as returned by io.open.
+	io_open = function(filename, mode, ...)
+		local sep = package.config:sub(1, 1)
+		if sep ~= '\\' and consul_build == "Rome2" then
+			-- macOS: only prepend base for relative paths
+			if filename:sub(1, 1) ~= '/' then
+				local home = os.getenv('HOME') or '/tmp'
+				filename = home .. '/Library/Application Support/Steam/steamapps/common/Total War Rome II/' .. filename
+			end
+		end
+		return io.open(filename, mode, ...)
+	end,
 
 	env = {
 
@@ -240,7 +258,7 @@ consul = {
 				local final_filename = filename or consul.debug.profile._filename
 				local report = consul.debug.profile._profiler.report()
 
-				local f = io.open(final_filename, "w")
+				local f = consul.io_open(final_filename, "w")
 				if f then
 					f:write(report)
 					f:close()
@@ -744,7 +762,7 @@ consul = {
 
 			log:debug("Reading config file: " .. config.path)
 
-			local f = io.open(config.path, "r")
+			local f = consul.io_open(config.path, "r")
 			if f then
 				log:debug("File exists: " .. config.path)
 				local f_content = f:read("*all")
@@ -779,7 +797,7 @@ consul = {
 		write = function(cfg)
 			local log = consul.new_log("config:write")
 			log:debug("Writing config file: " .. consul.config.path)
-			local f = io.open(consul.config.path, "w")
+			local f = consul.io_open(consul.config.path, "w")
 			if f then
 				-- remember to pass maxlevel as Rome2 LUA has no math.huge defined
 				f:write(consul.serpent.dump(cfg, { maxlevel = 10000, comment = false, indent = "\t" }))
@@ -1491,7 +1509,7 @@ consul = {
 					table.remove(hst.entries, 1)
 				end
 				-- write the entry to the history file
-				local f = io.open(hst.path, "a")
+				local f = consul.io_open(hst.path, "a")
 				if f then
 					f:write(entry .. "\n")
 					f:close()
@@ -1504,14 +1522,14 @@ consul = {
 		-- reads the initial history from the history file
 		read = function()
 			local hst = consul.history
-			local f = io.open(hst.path, "r")
+			local f = consul.io_open(hst.path, "r")
 			if f then
 				for line in f:lines() do
 					table.insert(hst.entries, line)
 				end
 				f:close()
 			else
-				local f = io.open(hst.path, "w")
+				local f = consul.io_open(hst.path, "w")
 				if f then
 					f:close()
 				end
@@ -1523,7 +1541,7 @@ consul = {
 		-- appends the current entry to the history file
 		append = function(entry)
 			local hst = consul.history
-			local f = io.open(hst.path, "a")
+			local f = consul.io_open(hst.path, "a")
 			if f then
 				f:write(entry .. "\n")
 				f:close()
@@ -1625,7 +1643,7 @@ consul = {
 		--- @usage consul.console.write("hello from script")
 		write = function(msg)
 			-- raw dump to file
-			local f = io.open(consul.console.output_path, "a")
+			local f = consul.io_open(consul.console.output_path, "a")
 			if f then
 				f:write(msg .. "\n")
 				f:close()
@@ -2698,7 +2716,7 @@ This is some information about the CliExecute functions in the base game.
 					console.clear()
 					settings._autoclear_current = 0
 					-- clear output file
-					local f = io.open(console.output_path, "w")
+					local f = consul.io_open(console.output_path, "w")
 					if f then
 						f:close()
 					end
@@ -2825,27 +2843,27 @@ consul.console.write(
 			local path = consul.scriptum.path
 			local max = consul.scriptum.max_entries
 
-			local f = io.open(path, "r")
+			local f = consul.io_open(path, "r")
 			if f then
 				f:close()
 			end
 
 			if not f then
 				-- create consul.scriptum
-				f = io.open(path, "w")
+				f = consul.io_open(path, "w")
 				if f then
 					f:write(consul.scriptum.path_example .. "\n")
 					f:close()
 				end
 
 				-- create consul_example.lua
-				f = io.open(consul.scriptum.path_example, "r")
+				f = consul.io_open(consul.scriptum.path_example, "r")
 				if f then
 					log:debug("Example script exists: " .. consul.scriptum.path_example)
 					f:close()
 				else
 					log:debug("Creating example script: " .. consul.scriptum.path_example)
-					f = io.open(consul.scriptum.path_example, "w")
+					f = consul.io_open(consul.scriptum.path_example, "w")
 					if f then
 						f:write(consul.scriptum.example_script)
 						f:close()
@@ -2884,7 +2902,7 @@ consul.console.write(
 
 			-- first read all lines to local var so we can close the file
 			local lines = {}
-			f = io.open(path, "r")
+			f = consul.io_open(path, "r")
 			if not f then
 				log:error("Could not open scriptum file, this should never happen " .. path)
 				return
@@ -2910,7 +2928,7 @@ consul.console.write(
 				-- make sure the line is not empty
 				if line ~= "" then
 					-- if the file exists, add it to the list
-					local f = io.open(line, "r")
+					local f = consul.io_open(line, "r")
 					if f then
 						f:close()
 

--- a/src/consul/consul_logging.lua
+++ b/src/consul/consul_logging.lua
@@ -54,7 +54,7 @@ end
 
 -- Internal method to write directly to the log file
 function Logger:_write_to_file(text)
-    local logfile, err = io.open(self.log_file_path, "a")
+    local logfile, err = consul.io_open(self.log_file_path, "a")
     if not logfile then
         error("Failed to open log file: " .. (err or "Unknown error"))
     end

--- a/src/consul/consul_uidebug.lua
+++ b/src/consul/consul_uidebug.lua
@@ -154,7 +154,7 @@ uidebug.dump_tree = function(root_component, hovered_address)
 		end
 	end
 
-	local file, err_open = io.open(UI_DEBUG_DIR .. "consul_debug_ui_state.txt", "w+")
+	local file, err_open = consul.io_open(UI_DEBUG_DIR .. "consul_debug_ui_state.txt", "w+")
 	if not file then
 		consul.log:error("uidebug: Could not open output file: " .. tostring(err_open))
 		return
@@ -185,7 +185,7 @@ uidebug.launch = function()
 	content = content:gsub("%[%[DYNAMIC_PATH%]%]", UI_DEBUG_DIR_NAME)
 	content = content:gsub("%[%[GAME_ID%]%]", game_subfolder)
 
-	local f_out = io.open(output_path, "w")
+	local f_out = consul.io_open(output_path, "w")
 	if not f_out then
 		return "Error: Could not write to " .. output_path
 	end
@@ -198,7 +198,7 @@ uidebug.launch = function()
 end
 
 uidebug.process_commands = function()
-	local f = io.open(UI_DEBUG_DIR .. "consul_debug_ui_command.txt", "r")
+	local f = consul.io_open(UI_DEBUG_DIR .. "consul_debug_ui_command.txt", "r")
 	if not f then
 		return
 	end
@@ -208,7 +208,7 @@ uidebug.process_commands = function()
 
 	if content and content ~= "" then
 		-- clear the file immediately
-		local fw = io.open(UI_DEBUG_DIR .. "consul_debug_ui_command.txt", "w")
+		local fw = consul.io_open(UI_DEBUG_DIR .. "consul_debug_ui_command.txt", "w")
 		if fw then
 			fw:close()
 		end

--- a/src/lua_scripts/all_scripted_rome2.lua
+++ b/src/lua_scripts/all_scripted_rome2.lua
@@ -18,10 +18,28 @@ for n,v in ipairs(events.historical_events) do print(n, v) end
 --]]
 
 -- Ensure logging to a file if something goes wrong
+-- On macOS the working directory may be the filesystem root (protected),
+-- so fall back to the user's home directory.
+local __log_path
+do
+    local sep = package.config:sub(1, 1)
+    if sep == '\\' then
+        -- Windows: write relative to the current working directory
+        __log_path = 'consul.log'
+    else
+        -- macOS / Linux: write to the user's home directory
+        local home = os.getenv('HOME') or '/tmp'
+        __log_path = home .. '/Library/Application Support/Steam/steamapps/common/Total War Rome II/' .. '/consul.log'
+       
+    end
+end
+
 local __write = function(line)
-    local f = io.open('consul.log', 'a')
-    f:write(line)
-    f:close()
+    local f = io.open(__log_path, 'a')
+    if f then
+        f:write(line)
+        f:close()
+    end
 end
 
 __write('Starting consul\n')


### PR DESCRIPTION
The point is to add support for Mac OS version, for now for Rome2 only
fix #5 Scriptum button has no effect on macos
  - Create a "os detection" in both all_scripted_rome2.lua and consul.lua
  - in consul.lua, create a io_open method for being able to open the targeted file on both windows and macos
linked to [Scriptum button has no effect on macos #5](https://github.com/bukowa/ConsulScriptum/issues/5)